### PR TITLE
Remove imports of substrait

### DIFF
--- a/proto/mohair/algebra.proto
+++ b/proto/mohair/algebra.proto
@@ -4,8 +4,6 @@ syntax = "proto3";
 package mohair;
 
 import "google/protobuf/any.proto";
-import "substrait/extensions/extensions.proto";
-import "substrait/type.proto";
 
 
 /**


### PR DESCRIPTION
This PR addresses #1 by removing the import clauses that refer to substrait.